### PR TITLE
added link to TCGA pathology reports. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository will be a summary and outlook on all our open, medical, AI advan
 
 ## Datasets
 - [1] image-text pairs of pathology images (~10k) [Go to dataset](https://warwick.ac.uk/fac/cross_fac/tia/data/arch)
-
+- TCGA Slide-caption pairs (~3K) with captions scraped from pathology reports [Go to dataset](https://gitlab.com/BioAI/pathology-report-information-extraction) [Scraping methodology](https://ieeexplore.ieee.org/document/9313347)
 ## Methods
 - Fine-tuning existing CLIP models
 


### PR DESCRIPTION
The matching images still need to be pulled together, but they are available to the public from different sources, (e.g. by cohort from https://www.cancerimagingarchive.net/collections/), or to people with TCGA access from GDC. 